### PR TITLE
fix eslint warnings

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -48,6 +48,9 @@ const Navbar = class extends React.Component {
             <div
               className={`navbar-burger burger ${this.state.navBarActiveClass}`}
               data-target="navMenu"
+              role="menuitem"
+              tabIndex={0}
+              onKeyPress={() => this.toggleHamburger()}
               onClick={() => this.toggleHamburger()}
             >
               <span />


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->


<!-- In addition to that please answer these questions: -->

Fix eslint warnings. Please check the following for the warnings.

warn ESLintError:
Navbar.js
  48:13  warning  Static HTML elements with event handlers require a role     jsx-a11y/no-static-element-interactions
  51:15  warning  `tabIndex` should only be declared on interactive elements  jsx-a11y/no-noninteractive-tabindex

✖ 2 problems (0 errors, 2 warnings)

success Building development bundle - 28.113s
 WARNING  Compiled with 1 warnings                                                                               0:57:20
⠀
Module Warning (from ./node_modules/eslint-loader/index.js):

Navbar.js
  48:13  warning  Static HTML elements with event handlers require a role     jsx-a11y/no-static-element-interactions
  51:15  warning  `tabIndex` should only be declared on interactive elements  jsx-a11y/no-noninteractive-tabindex

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

This is not a breaking change.